### PR TITLE
Make the build reproducible

### DIFF
--- a/podwrapper.pl.in
+++ b/podwrapper.pl.in
@@ -227,7 +227,7 @@ if (!$date && -d $filename) {
     $date = $1 if /^(\d+-\d+-\d+)\s/;
 }
 if (!$date) {
-    my ($day, $month, $year) = (localtime)[3,4,5];
+    my ($day, $month, $year) = (gmtime($ENV{SOURCE_DATE_EPOCH} || time))[3,4,5];
     $date = sprintf ("%04d-%02d-%02d", $year+1900, $month+1, $day);
 }
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that libnbd could not be built reproducibly.

This is due to it shipping a `.pod` generation wrapper that does not use/respect [SOURCE_DATE_EPOCH](https://reproducible-builds.org/docs/source-date-epoch/) and additionally varies the output depending on the build user's current timezone.

(This was originally filed in Debian as [#939546](https://bugs.debian.org/939546).)