### PR TITLE
interop: Skip nbd-server tests if it does not support inetd mode

### DIFF
--- a/interop/Makefile.am
+++ b/interop/Makefile.am
@@ -74,6 +74,7 @@ interop_nbd_server_SOURCES = \
 	$(NULL)
 interop_nbd_server_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
+	-DREQUIRES=' requires ("source ../tests/functions.sh; requires_nbd_server_supports_inetd"); ' \
 	-DNEEDS_TMPFILE=1 \
 	-DSERVER=\"$(NBD_SERVER)\" \
 	-DSERVER_PARAMS='"-d", "-C", "/dev/null", "0", TMPFILE' \
@@ -88,7 +89,7 @@ interop_nbd_server_tls_SOURCES = \
 	$(NULL)
 interop_nbd_server_tls_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
-	-DREQUIRES=' requires ("test -d $(abs_top_builddir)/tests/pki"); ' \
+	-DREQUIRES=' requires ("test -d $(abs_top_builddir)/tests/pki"); requires ("source ../tests/functions.sh; requires_nbd_server_supports_inetd"); ' \
 	-DNEEDS_TMPFILE=1 \
 	-DSERVER=\"$(NBD_SERVER)\" \
 	-DSERVER_PARAMS='"-d", "-C", "nbd-server-tls.conf", "0", TMPFILE' \
@@ -108,6 +109,7 @@ list_exports_nbd_server_SOURCES = \
 	$(NULL)
 list_exports_nbd_server_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
+	-DREQUIRES=' requires ("source ../tests/functions.sh; requires_nbd_server_supports_inetd"); ' \
 	-DSERVER=\"$(NBD_SERVER)\" \
 	-DSERVER_PARAMS='"-C", "$(srcdir)/list-exports-nbd-config", "-d", "0"' \
 	-DEXPORTS='"disk1", "disk2"' \

--- a/tests/functions.sh.in
+++ b/tests/functions.sh.in
@@ -76,6 +76,15 @@ requires ()
     }
 }
 
+# Opposite of requires - the test must not succeed.
+requires_not ()
+{
+    if ( "$@" ) </dev/null >/dev/null 2>&1 ; then
+        echo "$0: test prerequisite is missing or not working"
+        exit 77
+    fi
+}
+
 # Test host kernel is Linux and minimum version.
 #
 # It's usually better to test features rather than using this, but
@@ -136,21 +145,27 @@ requires_caps ()
     done
 }
 
+# requires_nbd_server_supports_inetd
+#
+# On some distros, nbd-server is built without support for syslog
+# which prevents use of inetd mode.  Instead nbd-server will exit with
+# this error:
+#
+#   Error: inetd mode requires syslog
+#   Exiting.
+#
+# https://listman.redhat.com/archives/libguestfs/2022-January/msg00003.html
+requires_nbd_server_supports_inetd ()
+{
+    requires_not grep 'inetd mode requires syslog' "$(type -p "@NBD_SERVER@")"
+}
+
 # Tests that run under check-root should use this.
 requires_root ()
 {
     if test $(id -u) -ne 0; then
         echo "$0: test skipped because not running as root"
         echo "$0: use ‘sudo make check-root’ to run these tests"
-        exit 77
-    fi
-}
-
-# Opposite of requires - the test must not succeed.
-requires_not ()
-{
-    if ( "$@" ) </dev/null >/dev/null 2>&1 ; then
-        echo "$0: test prerequisite is missing or not working"
         exit 77
     fi
 }


### PR DESCRIPTION
On some distros nbd-server is built without support for syslog which
prevents use of inetd mode.  Instead nbd-server will exit with this
error:

  Error: inetd mode requires syslog
  Exiting.

This commit adds a requires test for this and uses it around the
appropriate tests.

It would be nice to test, for example, if nbd-server prints the NBD
magic string on stdout.  However that doesn't work because nbd-server
uses socket calls (like send(2)) and fails unless we use a socket
connected to stdin/stdout, which would require a much more complex
test.  We could also use libnbd to test if inetd is working, but
that's what we're trying to test in the first place.  So instead I
went for the easy but inelegant way out - see if the error message is
compiled into the binary.